### PR TITLE
Fix to allow empty environment variables.  Environment variables

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -90,7 +90,7 @@ class Environment {
 			$value = getenv($variable);
 		}
 
-		if ($value == false || empty($value))
+        if (!isset($variable))
 		{
 			if ($default === '#default#')
 			{


### PR DESCRIPTION
Fix to allow empty environment variables.  Environment variables can be empty and still be valid.
Empty values should still be attempted to be used.  Changed to isset()