### PR TITLE
AspectMock fix

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -52,7 +52,8 @@ class Environment {
 				static::raiseEnvironmentVariableNotSet();
 			}
 
-			foreach (require $file as $key => $value)
+			$data = require $file;
+			foreach ($data as $key => $value)
 			{
 			    putenv(sprintf('%s=%s', $key, static::toString($value)));
 			}


### PR DESCRIPTION
When mocking ZipCode with Aspectmock there's an error in pragmarx/support:
```
syntax error, unexpected 'as' (T_AS) in /vendor/pragmarx/support/src/Environment.php on line 55
```

Here's a simple fix that solves the problem with AspectMock.

Reference: https://github.com/Codeception/AspectMock/issues/68