### PR TITLE
Address #13 and drop laravel 4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,7 @@
     "autoload": {
         "psr-4": {
             "PragmaRX\\Support\\": "src/"
-        },
-        "files": [
-            "src/helpers.php"
-        ]
+        }
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pragmarx/support",
+    "name": "fgreinus/antonioribeiro-support",
 
     "description": "PragmaRX components support package",
 
@@ -29,11 +29,5 @@
 
     "suggest": {
         "laravel/framework": "Laravel framework."
-    },
-
-    "extra": {
-        "branch-alias": {
-            "dev-master": "0.7.x-dev"
-        }
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -43,6 +43,8 @@ abstract class ServiceProvider extends IlluminateServiceProvider {
 		$this->publishFiles();
 
 		$this->loadViews();
+
+		$this->loadHelper();
 	}
 
 	/**
@@ -54,6 +56,8 @@ abstract class ServiceProvider extends IlluminateServiceProvider {
 	{
 		if ( ! $this->registered)
 		{
+//		    $this->loadHelper();
+
 			$this->mergeConfig();
 
 			$this->registerNamespace();
@@ -84,13 +88,6 @@ abstract class ServiceProvider extends IlluminateServiceProvider {
 	 */
 	public function getConfig($key = null)
 	{
-		if ( ! isLaravel5())
-		{
-			$key = $this->packageNamespace . ($key ? '::'.$key : '');
-
-			return $this->app['config']->get($key);
-		}
-
 		// Waiting for https://github.com/laravel/framework/pull/7440
 		// return $this->app['config']->get("{$this->packageVendor}.{$this->packageName}.config.{$key}");
 
@@ -106,22 +103,12 @@ abstract class ServiceProvider extends IlluminateServiceProvider {
 	 */
 	private function registerConfig()
 	{
-		if ( ! isLaravel5())
-		{
-			/// Fix a possible Laravel Bug
-			$this->app->register('Illuminate\Translation\TranslationServiceProvider');
-
-			$this->app['config']->package($this->packageNamespace, __DIR__.'/../../config', $this->packageNamespace);
-
-			$this->package($this->packageNamespace, $this->packageNamespace, $this->getRootDirectory());
-		}
-
 		$this->app->singleton($this->packageName.'.config', function($app)
 		{
 			// Waiting for https://github.com/laravel/framework/pull/7440
-			// return new Config($app['config'], $this->packageNamespace . ( ! isLaravel5() ? '::' : '.config.'));
+			// return new Config($app['config'], $this->packageNamespace . '.config.');
 
-			return new Config($app['config'], $this->packageNamespace . ( ! isLaravel5() ? '::' : '.'));
+			return new Config($app['config'], $this->packageNamespace . '.');
 		});
 	}
 
@@ -150,71 +137,51 @@ abstract class ServiceProvider extends IlluminateServiceProvider {
 
 	private function publishFiles()
 	{
-		if (isLaravel5())
-		{
-			if (file_exists($configFile = $this->getRootDirectory().DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'config.php'))
-			{
-				$this->publishes(
-					[ $configFile => config_path($this->packageName.'.php') ],
-					'config'
-				);
-			}
+        if (file_exists($configFile = $this->getRootDirectory().DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'config.php'))
+        {
+            $this->publishes(
+                [ $configFile => config_path($this->packageName.'.php') ],
+                'config'
+            );
+        }
 
-			if (file_exists($migrationsPath = $this->getRootDirectory().DIRECTORY_SEPARATOR.'migrations'))
-			{
-				$this->publishes(
-					[ $migrationsPath => base_path('database'.DIRECTORY_SEPARATOR.'migrations') ],
-					'migrations'
-				);
-			}
-		}
+        if (file_exists($migrationsPath = $this->getRootDirectory().DIRECTORY_SEPARATOR.'migrations'))
+        {
+            $this->publishes(
+                [ $migrationsPath => base_path('database'.DIRECTORY_SEPARATOR.'migrations') ],
+                'migrations'
+            );
+        }
 	}
 
 	private function mergeConfig()
 	{
-		if (isLaravel5())
-		{
-			if (file_exists($configFile = $this->getRootDirectory().DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'config.php'))
-			{
-				$this->mergeConfigFrom(
-					$configFile, $this->packageName
-				);
-			}
-		}
+        if (file_exists($configFile = $this->getRootDirectory().DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'config.php'))
+        {
+            $this->mergeConfigFrom(
+                $configFile, $this->packageName
+            );
+        }
 	}
 
 	private function registerNamespace()
 	{
-		if ( ! isLaravel5())
-		{
-			$this->packageNamespace = "$this->packageVendor/$this->packageName";
-		}
-		else
-		{
-			// Waiting for https://github.com/laravel/framework/pull/7440
-			// $this->packageNamespace = "$this->packageVendor.$this->packageName";
+        // Waiting for https://github.com/laravel/framework/pull/7440
+        // $this->packageNamespace = "$this->packageVendor.$this->packageName";
 
-			$this->packageNamespace = $this->packageName;
-		}
+        $this->packageNamespace = $this->packageName;
 	}
 
 	private function loadViews()
 	{
-		if (isLaravel5())
-		{
-			if (file_exists($viewsFolder = $this->getRootDirectory() . DIRECTORY_SEPARATOR . 'views'))
-			{
-				$this->loadViewsFrom($viewsFolder, "{$this->packageVendor}/{$this->packageName}");
-			}
-		}
-		else
-		{
-			$this->app->make('view')->addNamespace
-			(
-					$this->packageNamespace,
-					$this->getRootDirectory().'/views'
-			);
-		}
+        if (file_exists($viewsFolder = $this->getRootDirectory() . DIRECTORY_SEPARATOR . 'views'))
+        {
+            $this->loadViewsFrom($viewsFolder, "{$this->packageVendor}/{$this->packageName}");
+        }
 	}
 
+	private function loadHelper()
+    {
+        require_once('helpers.php');
+    }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -43,9 +43,7 @@ abstract class ServiceProvider extends IlluminateServiceProvider {
 		$this->publishFiles();
 
 		$this->loadViews();
-
-		$this->loadHelper();
-	}
+    }
 
 	/**
 	 * Boot for the child ServiceProvider
@@ -56,9 +54,9 @@ abstract class ServiceProvider extends IlluminateServiceProvider {
 	{
 		if ( ! $this->registered)
 		{
-//		    $this->loadHelper();
+            $this->loadHelper();
 
-			$this->mergeConfig();
+            $this->mergeConfig();
 
 			$this->registerNamespace();
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -795,55 +795,33 @@ if ( ! function_exists( 'closure_dump' ))
 	}
 }
 
-if ( ! function_exists( 'isLaravel5' ))
-{
-    function isLaravel5()
-    {
-        return Laravel::VERSION >= '5.0.0';
-    }
-
-    function isLaravel53()
-    {
-        return Laravel::VERSION >= '5.3.0';
-    }
-}
-
 if ( ! function_exists( 'db_listen' ))
 {
     function db_listen($dump = true, $log = true)
 	{
-        if (! isLaravel53()) {
-            \DB::listen(function($sql, $bindings, $time) use ($dump, $log)
-            {
-                if ($dump)
-                {
-                    var_dump($sql);
-                    var_dump($bindings);
-                }
-
-                if ($log)
-                {
-                    \Log::info($sql);
-                    \Log::info($bindings);
-                }
-            });
-        }
-        else
+        \DB::listen(function() use ($dump, $log)
         {
-            \DB::listen(function($query) use ($dump, $log) {
-                if ($dump)
-                {
-                    var_dump($query->sql);
-                    var_dump($query->bindings);
-                }
+            $arguments = func_get_args();
 
-                if ($log)
-                {
-                    \Log::info($query->sql);
-                    \Log::info($query->bindings);
-                }
-            });
-        }
+            if (is_object($arguments[0])) {
+                $sql = $arguments[0]->sql;
+                $bindings = $arguments[0]->bindings;
+            } else {
+                $sql = $arguments[0];
+                $bindings = $arguments[1];
+            }
+            if ($dump)
+            {
+                var_dump($sql);
+                var_dump($bindings);
+            }
+
+            if ($log)
+            {
+                \Log::info($sql);
+                \Log::info($bindings);
+            }
+        });
 	}
 }
 
@@ -934,14 +912,6 @@ if ( ! function_exists( 'flip_coin' ))
 	function flip_coin()
 	{
 		return mt_rand(0, 1);
-	}
-}
-
-if ( ! function_exists( 'csrf_token' ) && ! isLaravel5())
-{
-	function csrf_token()
-	{
-		return app()->make('session.store')->getToken();
 	}
 }
 


### PR DESCRIPTION
Hey there,

i tried to come up with a solution for issue #13 .

The only clean way to do this (in my opinion) is to drop support for laravel 4.

I also refactored db_listen function to be able to remove the isLaravel53 function.
Thing is, that when accessing Laravel::VERSION from within the package, the php artisan optimize command seem to bug. Maybe some double-loaded application stack due to the helpers file being loaded too early or so...

These changes fixed the problem.

BTW: Taylor's opinion on how to support different laravel versions https://twitter.com/taylorotwell/status/512050601115414528.