### PR TITLE
Add var-dumper ~4.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/filesystem": "~4.0|~5.0",
-        "symfony/var-dumper": "~2.6|~3.0"
+        "symfony/var-dumper": "~2.6|~3.0|~4.0"
     },
 
     "autoload": {


### PR DESCRIPTION
This allows installation with Laravel 5.6