### PR TITLE
Use Contract instead of Concrete to play better with others

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -2,7 +2,7 @@
 
 namespace PragmaRX\Support;
 
-use Illuminate\Config\Repository as IlluminateConfig;
+use Illuminate\Contracts\Config\Repository as IlluminateConfig;
 
 class Config {
 


### PR DESCRIPTION
This simple change allows extended classes to be used instead of being too rigid.