### PR TITLE
fixed Undefined offset in IpAddress::cidrToRange

### DIFF
--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -229,6 +229,11 @@ class IpAddress
 
 		$cidr = explode('/', $cidr);
 
+		if (count($cidr) !== 2) {
+			return false;
+		}
+
+
 		$range[0] = long2ip((ip2long($cidr[0])) & ((-1 << (32 - (int)$cidr[1]))));
 
 		$range[1] = long2ip((ip2long($cidr[0])) + pow(2, (32 - (int)$cidr[1])) - 1);


### PR DESCRIPTION
The cidrToRange() function is called by Firewall for any entry, not just cidr ranges.
Because the parent function has the function call in a try-catch block, this isn't an issue.

However, many users report warnings thrown by cidrToRange(), as is referenced here:
https://github.com/antonioribeiro/firewall/issues/137

These warnings aren't circumvented by the try-catch block,
but this additional check should prevent them altogether.