### PR TITLE
Added Support for laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/filesystem": "~4.0|~5.0|~6.0|~7.0",
-        "symfony/var-dumper": "~2.6|~3.0|~4.0"
+        "symfony/var-dumper": "~2.6|~3.0|~4.0|~5.0"
     },
 
     "autoload": {


### PR DESCRIPTION
Hi,
In the last commit there was a dependency issue for latest version of Laravel (laravel/framework 7.x-dev requires symfony/var-dumper ^5.0). I have added this to composer.json in order to fix this issue.
Please merge it.
Thanks