### PR TITLE
Fix symfony/var-dumper version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/filesystem": "~4.0|~5.0|~6.0|~7.0|~8.0|~9.0|~10.0|~11.0",
-        "symfony/var-dumper": "~2.6|~3.0|~4.0|~5.0|~6.0"
+        "symfony/var-dumper": "~2.6|~3.0|~4.0|~5.0|~6.0|~7.0"
     },
 
     "autoload": {


### PR DESCRIPTION
To be compatible with Laravel 11